### PR TITLE
Allow infering HCL tags from JSON tags via config option

### DIFF
--- a/marshal_test.go
+++ b/marshal_test.go
@@ -83,6 +83,7 @@ func TestMarshal(t *testing.T) {
 		name     string
 		src      interface{}
 		expected string
+		options  []MarshalOption
 	}{
 		{name: "Scalars",
 			src: &struct {
@@ -145,10 +146,27 @@ text = "hello"
 json = "{\"hello\":\"world\"}"
 `,
 		},
+		{name: "JsonTags",
+			src: &struct {
+				Block struct {
+					Str string `json:"str"`
+				} `json:"block"`
+			}{
+				Block: struct {
+					Str string `json:"str"`
+				}{Str: "val"},
+			},
+			expected: `
+block {
+  str = "val"
+}
+`,
+			options: []MarshalOption{InferHCLTags(true)},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			data, err := Marshal(test.src)
+			data, err := Marshal(test.src, test.options...)
 			require.NoError(t, err)
 			require.Equal(t, strings.TrimSpace(test.expected), strings.TrimSpace(string(data)))
 		})

--- a/schema_test.go
+++ b/schema_test.go
@@ -188,3 +188,41 @@ block "label" {
 `),
 		strings.TrimSpace(string(data)))
 }
+
+func TestJsonTaggedSchema(t *testing.T) {
+	type KeyValue struct {
+		Key   string `json:"key"`
+		Value string `json:"value,omitempty"`
+	}
+
+	type jsonTaggedSchema struct {
+		Str     string    `json:"str"`
+		Config  KeyValue  `json:"config"`
+		Options *KeyValue `json:"options,omitempty"`
+	}
+
+	var val interface{}
+	val = &jsonTaggedSchema{
+		Str:     "testSchema",
+		Config:  KeyValue{"key1", "val1"},
+		Options: &KeyValue{},
+	}
+	schema, err := Schema(val, InferHCLTags(true))
+	require.NoError(t, err)
+	data, err := MarshalAST(schema)
+	require.NoError(t, err)
+	expectedSchema := `
+str = string
+
+config {
+  key = string
+  value = string // (optional)
+}
+
+options {
+  key = string
+  value = string // (optional)
+}
+    `
+	require.Equal(t, strings.TrimSpace(expectedSchema), strings.TrimSpace(string(data)))
+}


### PR DESCRIPTION
Renamed options to ```marshallOptions``` as tag parsing is invoked from both marshalling/unmarshalling code paths. The options can be broken down further if required for marshall/unmarshall.