### PR TITLE
Infer slice of struct tagged with json if the option is enabled

### DIFF
--- a/marshal_test.go
+++ b/marshal_test.go
@@ -220,6 +220,23 @@ mapDiffDefault = {
 }
 `,
 		},
+		{name: "JsonBlockSlice",
+			src: &struct {
+				Block struct {
+					Str string `json:"str"`
+				} `json:"block"`
+			}{
+				Block: struct {
+					Str string `json:"str"`
+				}{Str: "val"},
+			},
+			expected: `
+block {
+  str = "val"
+}
+`,
+			options: []MarshalOption{InferHCLTags(true)},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -478,7 +478,7 @@ func parseTag(parent reflect.Type, f field, opt *marshalOptions) tag {
 	if !ok && opt.inferHCLTags {
 		// if the struct field is a struct or pointer to struct set the tag as block
 		tt := t.Type
-		for tt.Kind() == reflect.Ptr {
+		for tt.Kind() == reflect.Ptr || tt.Kind() == reflect.Slice {
 			tt = tt.Elem()
 		}
 		isBlock = tt.Kind() == reflect.Struct

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -787,3 +787,39 @@ val = 17
 
 	runTests(t, tests)
 }
+
+func TestUnmarshalJsonTaggedBlock(t *testing.T) {
+	hcl := `
+str = "test"
+
+config {
+  key = "inferHCLTags"
+  value = "yes"
+}
+
+refs {
+  name = "ref1"
+}
+
+refs {
+  name = "ref2"
+}
+
+refs {
+  name = "ref3"
+}
+`
+	expected := jsonTaggedSchema{
+		Str: "test",
+		Config: keyValue{
+			Key:   "inferHCLTags",
+			Value: "yes",
+		},
+		Options: nil,
+		Refs:    []objectRef{{"ref1"}, {"ref2"}, {"ref3"}},
+	}
+	var actual jsonTaggedSchema
+	err := Unmarshal([]byte(hcl), &actual)
+	require.NoError(t, err)
+	require.Equal(t, actual, expected)
+}


### PR DESCRIPTION
This is currently not being detected which is preventing from parsing slice of structs with json tags