### PR TITLE
Don't include word borders for Number lexer rule

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,5 @@
-github.com/alecthomas/participle v0.5.1-0.20200823102910-f1fadea505e5 h1:ztOtDor4NVD69lMgXVZuf6RXSXtwZcJ5tUuHGdq36ao=
-github.com/alecthomas/participle v0.5.1-0.20200823102910-f1fadea505e5/go.mod h1:HfdmEuwvr12HXQN44HPWXR0lHmVolVYe4dyL6lQ3duY=
 github.com/alecthomas/participle v0.6.1-0.20200911005820-318127ca69ac h1:E1/zcnJ3CYONnRq6v5mR4NnyimIJHHIVu+EFdFLK3d4=
 github.com/alecthomas/participle v0.6.1-0.20200911005820-318127ca69ac/go.mod h1:HfdmEuwvr12HXQN44HPWXR0lHmVolVYe4dyL6lQ3duY=
-github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1 h1:GDQdwm/gAcJcLAKQQZGOJ4knlw+7rfEQQcmwTbt4p5E=
 github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=
 github.com/alecthomas/repr v0.0.0-20200325044227-4184120f674c h1:MVVbswUlqicyj8P/JljoocA7AyCo62gzD0O7jfvrhtE=
 github.com/alecthomas/repr v0.0.0-20200325044227-4184120f674c/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=

--- a/parser.go
+++ b/parser.go
@@ -349,7 +349,7 @@ var (
 	lex = lexer.Must(stateful.New(stateful.Rules{
 		"Root": {
 			{"Ident", `\b[[:alpha:]]\w*(-\w+)*\b`, nil},
-			{"Number", `\b^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?\b`, nil},
+			{"Number", `^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?`, nil},
 			{"Heredoc", `<<[-]?(\w+\b)`, stateful.Push("Heredoc")},
 			{"String", `"(\\\d\d\d|\\.|[^"])*"|'(\\\d\d\d|\\.|[^'])*'`, nil},
 			{"Punct", `[][{}=:,]`, nil},

--- a/parser_test.go
+++ b/parser_test.go
@@ -93,7 +93,10 @@ EOF
 				true_bool = true
 				false_bool = false
 				str = "string"
+				int = 1
+				negative_int = -1
 				float = 1.234
+				negative_float = -1.234
 				list = [1, 2, 3]
 				map = {
 					"a": 1,
@@ -105,7 +108,10 @@ EOF
 					attr("true_bool", hbool(true)),
 					attr("false_bool", hbool(false)),
 					attr("str", str("string")),
+					attr("int", num(1)),
+					attr("negative_int", num(-1)),
 					attr("float", num(1.234)),
+					attr("negative_float", num(-1.234)),
 					attr("list", list(num(1), num(2), num(3))),
 					attr("map", hmap(
 						hkv("a", num(1)),


### PR DESCRIPTION
Fixes #10

The word borders meant that negative numbers were not being parsed because of the leading `-` sign.