### PR TITLE
fix: remaining attributes for array of blocks

### DIFF
--- a/unmarshal.go
+++ b/unmarshal.go
@@ -108,7 +108,7 @@ func unmarshalEntries(v reflect.Value, entries []*Entry, opt *marshalState) erro
 			if field.t.Type != remainType {
 				panic(fmt.Sprintf(`"remain" field %q must be of type []*hcl.Entry but is %T`, field.t.Name, field.t.Type))
 			}
-			remaining := []*Entry{}
+			var remaining []*Entry
 			for _, entries := range mentries {
 				remaining = append(remaining, entries...)
 			}
@@ -235,6 +235,8 @@ func unmarshalEntries(v reflect.Value, entries []*Entry, opt *marshalState) erro
 					}
 					field.v.Set(reflect.Append(field.v, el))
 				}
+				// Remove all entries for a slice of struct after processing
+				mentries[tag.name] = nil
 				continue
 			}
 			fallthrough

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -388,6 +388,37 @@ are = true
 				normaliseEntries(i.(*remainStruct).Remain)
 			},
 		},
+		{name: "Remain with blocks",
+			hcl: `
+name = "hello"
+nested {
+  name = "my"
+}
+nested {
+  name = "your"
+}
+message1 = "wonderful"
+message2 = world
+`,
+			dest: remainStruct{
+				Name: "hello",
+				Nested: []*remainNested{
+					{
+						Name: "my",
+					},
+					{
+						Name: "your",
+					},
+				},
+				Remain: []*Entry{
+					attr("message1", str("wonderful")),
+					attr("message2", str("world")),
+				},
+			},
+			fixup: func(i interface{}) {
+				normaliseEntries(i.(*remainStruct).Remain)
+			},
+		},
 		{name: "UnmarshallJSONTaggedStruct",
 			hcl: `
                 block {
@@ -413,8 +444,13 @@ are = true
 }
 
 type remainStruct struct {
-	Name   string   `hcl:"name"`
-	Remain []*Entry `hcl:",remain"`
+	Name   string          `hcl:"name"`
+	Nested []*remainNested `hcl:"nested,optional"`
+	Remain []*Entry        `hcl:",remain"`
+}
+
+type remainNested struct {
+	Name string `hcl:"name"`
 }
 
 func intlistp(i ...int) *[]int { return &i }


### PR DESCRIPTION
This PR fixes an issue retrieving `remiaining` attributes in the presence of an array of blocks

https://github.com/alecthomas/hcl/issues/16