### PR TITLE
fix:  allow marshalling structs via interface{}

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -154,6 +154,9 @@ func marshalToAST(v interface{}, opt *marshalState) (*AST, error) {
 }
 
 func structToEntries(v reflect.Value, opt *marshalState) (entries []Entry, labels []string, err error) {
+	if v.Kind() == reflect.Interface {
+		v = v.Elem()
+	}
 	if v.Kind() == reflect.Ptr {
 		if v.IsNil() {
 			if !opt.schema {
@@ -417,6 +420,9 @@ func valueFromTag(f field, defaultValue string) (Value, error) {
 }
 
 func valueToValue(v reflect.Value, opt *marshalState) (Value, error) {
+	if v.Kind() == reflect.Interface {
+		v = v.Elem()
+	}
 	if v.Kind() == reflect.Ptr {
 		v = v.Elem()
 	}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -366,6 +366,21 @@ attr = "string"
 				} `hcl:"html,block"`
 			}{},
 			expected: ``},
+		{name: "MarshallStructViaInterface",
+			src: &struct {
+				IfaceBlock interface{} `hcl:"outer,block"`
+			}{
+				IfaceBlock: &struct {
+					Attr string `hcl:"attr"`
+				}{
+					Attr: "some string",
+				},
+			},
+			expected: `outer {
+  attr = "some string"
+}
+`,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
This PR allows providing structs (and struct pointers) that are defined as `interface{}`. e.g., this previously failed with: `call of reflect.Value.NumField on interface Value`

```go
type Tree struct {
  Objs []interface{} `hcl:"objs,block"`
}

type Object struct {
  Attr string `hcl:"attr"`
}

...
t := Tree{}
t.Objs = append(x.Objs, &Object{ Attr: "hello", })
hcl.MarshalToAST(&t)

```