### PR TITLE
fix: Support map keys that aren't strings

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -74,11 +74,15 @@ func attrSchema(t reflect.Type) (Value, error) {
 		return &List{List: []Value{el}}, nil
 
 	case reflect.Map:
-		el, err := attrSchema(t.Elem())
+		keyType, err := attrSchema(t.Key())
 		if err != nil {
 			return nil, err
 		}
-		return &Map{Entries: []*MapEntry{{Key: &Type{Type: strType}, Value: el}}}, nil
+		valType, err := attrSchema(t.Elem())
+		if err != nil {
+			return nil, err
+		}
+		return &Map{Entries: []*MapEntry{{Key: keyType, Value: valType}}}, nil
 
 	case reflect.Float32, reflect.Float64,
 		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,

--- a/schema_test.go
+++ b/schema_test.go
@@ -13,6 +13,8 @@ type testSchema struct {
 	Bool  bool           `hcl:"bool"`
 	List  []string       `hcl:"list"`
 	Map   map[string]int `hcl:"map" help:"A map."`
+	Map2  map[int]string `hcl:"map2" help:"Another map."`
+	Nope  string         `hcl:"-" help:"An ignored field."`
 	Block struct {
 		Name string  `hcl:"name,label"`
 		Attr *string `hcl:"attr"`
@@ -53,6 +55,10 @@ list = [string]
 // A map.
 map = {
   string: number,
+}
+// Another map.
+map2 = {
+  number: string,
 }
 
 // A block.


### PR DESCRIPTION
e.g.
```hcl
tcp-proxy = {
  13310 : "mysql"
}
```