### PR TITLE
fix: Roundtrip trailing comments within a block correctly.

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -689,8 +689,8 @@ func marshalBlock(w io.Writer, indent string, block *Block) error {
 		fmt.Fprintf(w, "%s", text)
 	}
 
-	// Check if block is empty
-	if len(block.Body) == 0 {
+	// Check if block is empty and has no trailing comments
+	if len(block.Body) == 0 && len(block.TrailingComments) == 0 {
 		fmt.Fprintln(w, " {}")
 		return nil
 	}
@@ -699,6 +699,13 @@ func marshalBlock(w io.Writer, indent string, block *Block) error {
 	err := marshalEntries(w, indent+"  ", block.Body)
 	if err != nil {
 		return err
+	}
+	// Marshal trailing comments before closing brace
+	if len(block.TrailingComments) > 0 {
+		if len(block.Body) > 0 {
+			fmt.Fprintln(w)
+		}
+		marshalComments(w, indent+"  ", block.TrailingComments)
 	}
 	fmt.Fprintf(w, "%s}\n", indent)
 	return nil

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -431,3 +431,33 @@ func TestOptionalDefaultOmitted(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "", string(data))
 }
+
+func TestMarshalAST(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+		ast      *AST
+	}{
+		{name: "BlockWithTrailingComments",
+			expected: `block {
+  attr = false
+
+  // trailing comment
+}
+`,
+			ast: hcl(&Block{
+				Name:             "block",
+				Body:             []Entry{attr("attr", hbool(false))},
+				TrailingComments: []string{"trailing comment"},
+			}),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			normaliseAST(test.ast)
+			b, err := MarshalAST(test.ast)
+			assert.NoError(t, err)
+			assert.Equal(t, test.expected, string(b))
+		})
+	}
+}

--- a/parser_test.go
+++ b/parser_test.go
@@ -169,6 +169,20 @@ EOF
 			`,
 			expected: hcl(block("block", nil, block("nested", nil))),
 		},
+		{name: "BlockWithTrailingComments",
+			hcl: `
+					block {
+					  attr = false
+
+					  // trailing comment
+					}
+				`,
+			expected: hcl(&Block{
+				Name:             "block",
+				Body:             []Entry{attr("attr", hbool(false))},
+				TrailingComments: []string{"trailing comment"},
+			}),
+		},
 		{name: "EmptyList",
 			hcl:      `a = []`,
 			expected: hcl(attr("a", list()))},


### PR DESCRIPTION
Given
```hcl
block {
  attr = true

  // trailing comments
}
```

the library is able to parse `"trailing comments"` into `Block.TrailingComments` but `marshal.go` does not have a codepath that writes `Block.TrailingComments` out.