### PR TITLE
fix: Preserve whitespace within comments

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -113,6 +113,58 @@ EOF
 				},
 			),
 		},
+		{name: "Comments with internal whitespace",
+			hcl: `
+				// Uncomment this to use it
+				// block {
+				//   env = {
+				//     KEY: value
+				//   } 
+				// }
+			`,
+			expected: &AST{
+				TrailingComments: []string{
+					"Uncomment this to use it",
+					"block {",
+					"  env = {",
+					"    KEY: value",
+					"  } ",
+					"}",
+				},
+			},
+		},
+		{name: "Multiline comments with varying indentation",
+			hcl: `
+				block {
+					//env = {
+					//  KEY: value
+					//}
+				}
+				block {
+					//   env = {
+					//     KEY: value
+					//   }
+				}
+			`,
+			expected: hcl(
+				&Block{
+					Name: "block",
+					TrailingComments: []string{
+						"env = {",
+						"  KEY: value",
+						"}",
+					},
+				},
+				&Block{
+					Name: "block",
+					TrailingComments: []string{
+						"env = {",
+						"  KEY: value",
+						"}",
+					},
+				},
+			),
+		},
 		{name: "Attributes",
 			hcl: `
 				true_bool = true


### PR DESCRIPTION
Given HCL like this:
```hcl
// Uncomment this to use it
// block {
//   env = {
//     KEY: value
//   }
// }
```

This PR solves an issue where parsing the HCL and then marshaling it again renders this:
```hcl
// Uncomment this to use it
// block {
// env = {
// KEY: value
// }
// }
```