### PR TITLE
feat: Add `WithDetachedComments`, a functional option for `Parse`, `ParseString`, and `ParseBytes`

### DIFF
--- a/marshal_test.go
+++ b/marshal_test.go
@@ -451,6 +451,38 @@ func TestMarshalAST(t *testing.T) {
 				TrailingComments: []string{"trailing comment"},
 			}),
 		},
+		{
+			name: "BlockWithDetachedCommentsAheadOfIt",
+			expected: `// detached comment 1
+
+// detached comment 2 (independent of detached comment 1)
+
+// attached comment (attached to following block)
+block {}
+
+// detached comment 3 (not attached to either the preceding or following block)
+
+block {}
+
+// detached comment 4 (not attached to either the preceding block or following comment)
+
+// trailing AST comment (not attached to preceding block)
+`,
+			ast: &AST{
+				Entries: []Entry{
+					&Comment{Comments: []string{"detached comment 1"}},
+					&Comment{Comments: []string{"detached comment 2 (independent of detached comment 1)"}},
+					&Block{
+						Name:     "block",
+						Comments: []string{"attached comment (attached to following block)"},
+					},
+					&Comment{Comments: []string{"detached comment 3 (not attached to either the preceding or following block)"}},
+					&Block{Name: "block"},
+					&Comment{Comments: []string{"detached comment 4 (not attached to either the preceding block or following comment)"}},
+				},
+				TrailingComments: []string{"trailing AST comment (not attached to preceding block)"},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/parser.go
+++ b/parser.go
@@ -56,6 +56,8 @@ func (e Entries) MarshalJSON() ([]byte, error) {
 			kind = "attribute"
 		case *Block:
 			kind = "block"
+		case *Comment:
+			continue
 		}
 		out = append(out, []byte(fmt.Sprintf(`{%q: %s}`, kind, raw)))
 	}
@@ -66,9 +68,9 @@ func (e Entries) MarshalJSON() ([]byte, error) {
 type AST struct {
 	Pos lexer.Position `parser:""`
 
-	Entries          Entries     `parser:"@@*"`
-	TrailingComments CommentList `parser:"@Comment*"`
-	Schema           bool        `parser:""`
+	Entries          Entries `parser:"@@*"`
+	TrailingComments CommentList
+	Schema           bool `parser:""`
 }
 
 func (a *AST) Detach() bool { return false }
@@ -124,7 +126,7 @@ type Attribute struct {
 	Pos    lexer.Position `parser:""`
 	Parent Node           `parser:""`
 
-	Comments CommentList `parser:"@Comment*"`
+	Comments CommentList
 
 	Key   string `parser:"@Ident"`
 	Value Value  `parser:"( '=':Punct @@ )?"`
@@ -160,19 +162,47 @@ func (a *Attribute) Clone() Entry {
 	}
 }
 
+type Comment struct {
+	Pos    lexer.Position `parser:""`
+	EndPos lexer.Position `parser:""`
+	Parent Node           `parser:""`
+
+	Comments CommentList `parser:"@Comment"`
+}
+
+var _ Entry = &Comment{}
+
+func (a *Comment) Detach() bool          { return detachEntry(a.Parent, a) }
+func (a *Comment) Position() Position    { return a.Pos }
+func (a *Comment) EndPosition() Position { return a.EndPos }
+func (a *Comment) EntryKey() string      { return "" }
+func (a *Comment) children() []Node      { return nil }
+func (a *Comment) String() string        { return "" }
+
+// Clone the AST.
+func (a *Comment) Clone() Entry {
+	if a == nil {
+		return nil
+	}
+	return &Comment{
+		Pos:      a.Pos,
+		Comments: cloneStrings(a.Comments),
+	}
+}
+
 // Block represents am optionally labelled HCL block.
 type Block struct {
 	Pos    lexer.Position `parser:""`
 	Parent Node           `parser:""`
 
-	Comments CommentList `parser:"@Comment*"`
+	Comments CommentList
 
 	Name     string   `parser:"@Ident"`
 	Repeated bool     `parser:"( '(' @'repeated' ')' )?"`
 	Labels   []string `parser:"@( Ident | String )*"`
-	Body     Entries  `parser:"'{' @@*"`
+	Body     Entries  `parser:"'{' @@* '}'"`
 
-	TrailingComments CommentList `parser:"@Comment* '}'"`
+	TrailingComments CommentList
 }
 
 var _ Entry = &Block{}
@@ -515,7 +545,7 @@ var (
 			{"Heredoc", `<<[-]?(\w+\b)`, lexer.Push("Heredoc")},
 			{"String", `"(\\\d\d\d|\\.|[^"])*"|'(\\\d\d\d|\\.|[^'])*'`, nil},
 			{"Punct", `[][*?{}=:,()|]`, nil},
-			{"Comment", `(?:(?://|#)[^\n]*(?:\n\s*(?://|#)[^\n]*)*)|/\*.*?\*/`, nil},
+			{"Comment", `(?:(?://|#)[^\n]*(?:\n[ \t]*(?://|#)[^\n]*)*)|/\*.*?\*/`, nil},
 			{"Whitespace", `\s+`, nil},
 		},
 		"Heredoc": {
@@ -531,7 +561,7 @@ var (
 		participle.Map(cleanHeredocStart, "Heredoc"),
 		participle.Map(stripComment, "Comment"),
 		participle.Elide("Whitespace"),
-		participle.Union[Entry](&Block{}, &Attribute{}),
+		participle.Union[Entry](&Block{}, &Attribute{}, &Comment{}),
 		participle.Union[Value](&Bool{}, &Type{}, &String{}, &Number{}, &List{}, &Map{}, &Heredoc{}),
 		// We need lookahead to ensure prefixed comments are associated with the right nodes.
 		participle.UseLookahead(50))
@@ -576,31 +606,197 @@ func cleanHeredocStart(token lexer.Token) (lexer.Token, error) {
 	return token, nil
 }
 
+// ParseOption represents a functional option for Parse, ParseString, and ParseBytes.
+type ParseOption func(*parseConfig)
+
+// parseConfig holds the configuration for parsing.
+type parseConfig struct {
+	detachedComments bool
+}
+
+// WithDetachedComments controls whether comments that are not directly associated with a
+// block or attribute are preserved in the AST.
+// If set to false (default), detached comments will be stripped from the AST during post-processing.
+// If set to true, detached comments will be preserved as separate entries in the AST.
+func WithDetachedComments(preserve bool) ParseOption {
+	return func(config *parseConfig) {
+		config.detachedComments = preserve
+	}
+}
+
 // Parse HCL from an io.Reader.
-func Parse(r io.Reader) (*AST, error) {
+func Parse(r io.Reader, options ...ParseOption) (*AST, error) {
+	config := &parseConfig{}
+	for _, option := range options {
+		option(config)
+	}
+
 	hcl, err := parser.Parse("", r)
 	if err != nil {
 		return nil, err
 	}
-	return hcl, AddParentRefs(hcl)
+
+	return config.postProccessAST(hcl)
 }
 
 // ParseString parses HCL from a string.
-func ParseString(str string) (*AST, error) {
+func ParseString(str string, options ...ParseOption) (*AST, error) {
+	config := &parseConfig{}
+	for _, option := range options {
+		option(config)
+	}
+
 	hcl, err := parser.ParseString("", str)
 	if err != nil {
 		return nil, err
 	}
-	return hcl, AddParentRefs(hcl)
+
+	return config.postProccessAST(hcl)
 }
 
 // ParseBytes parses HCL from bytes.
-func ParseBytes(data []byte) (*AST, error) {
+func ParseBytes(data []byte, options ...ParseOption) (*AST, error) {
+	config := &parseConfig{}
+	for _, option := range options {
+		option(config)
+	}
+
 	hcl, err := parser.ParseBytes("", data)
 	if err != nil {
 		return nil, err
 	}
-	return hcl, AddParentRefs(hcl)
+
+	return config.postProccessAST(hcl)
+}
+
+func (config *parseConfig) postProccessAST(hcl *AST) (*AST, error) {
+	err := AddParentRefs(hcl)
+	if err != nil {
+		return nil, err
+	}
+
+	// Always process comments to attach them appropriately
+	err = populateAttachedComments(hcl)
+	if err != nil {
+		return nil, err
+	}
+
+	err = populateTrailingComments(hcl)
+	if err != nil {
+		return nil, err
+	}
+
+	if !config.detachedComments {
+		err = stripDetachedComments(hcl)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return hcl, nil
+}
+
+// populateAttachedComments moves immediately adjacent comments to their following entries.
+// Comments that immediately precede a block/attribute (without blank lines) are "attached" and
+// should be moved to the Comments field of that block/attribute. Comments separated by blank lines
+// remain as standalone ("detached") Comment entries.
+func populateAttachedComments(ast *AST) error {
+	populateAttachedCommentsInEntries(&ast.Entries)
+
+	return visitBlocks(ast, func(block *Block) error {
+		populateAttachedCommentsInEntries(&block.Body)
+		return nil
+	})
+}
+
+// populateAttachedCommentsInEntries processes a slice of entries to handle attached vs detached comments
+func populateAttachedCommentsInEntries(entries *Entries) {
+	if entries == nil || len(*entries) == 0 {
+		return
+	}
+
+	newEntries := make(Entries, 0, len(*entries))
+
+	for i, entry := range *entries {
+		if comment, ok := entry.(*Comment); ok {
+			// Check if next entry exists and is immediately adjacent
+			if i+1 < len(*entries) {
+				nextEntry := (*entries)[i+1]
+				if nextEntry.Position().Line == comment.EndPosition().Line+1 {
+					switch e := nextEntry.(type) {
+					case *Block:
+						e.Comments = append(e.Comments, comment.Comments...)
+					case *Attribute:
+						e.Comments = append(e.Comments, comment.Comments...)
+					}
+					continue // Skip adding as standalone
+				}
+			}
+		}
+
+		newEntries = append(newEntries, entry)
+	}
+
+	*entries = newEntries
+}
+
+// populateTrailingComments copies trailing comments from Comment nodes to TrailingComments fields.
+func populateTrailingComments(ast *AST) error {
+	populateTrailingCommentsInEntries(&ast.Entries, &ast.TrailingComments)
+
+	return visitBlocks(ast, func(block *Block) error {
+		populateTrailingCommentsInEntries(&block.Body, &block.TrailingComments)
+		return nil
+	})
+}
+
+// populateTrailingCommentsInEntries finds trailing Comment nodes and copies their comments
+func populateTrailingCommentsInEntries(entries *Entries, trailingComments *CommentList) {
+	if entries == nil || len(*entries) == 0 {
+		return
+	}
+
+	// Only the very last entry should be considered a trailing comment
+	// (not all comments after the last non-comment entry)
+	lastIndex := len(*entries) - 1
+	if lastIndex >= 0 {
+		if comment, ok := (*entries)[lastIndex].(*Comment); ok {
+			*trailingComments = append(*trailingComments, comment.Comments...)
+			// Remove the trailing comment from entries
+			*entries = (*entries)[:lastIndex]
+		}
+	}
+}
+
+// stripDetachedComments removes all Comment nodes from the AST recursively.
+func stripDetachedComments(ast *AST) error {
+	stripCommentsFromEntries(&ast.Entries)
+
+	return visitBlocks(ast, func(block *Block) error {
+		stripCommentsFromEntries(&block.Body)
+		return nil
+	})
+}
+
+// stripCommentsFromEntries removes Comment entries from a slice of entries.
+func stripCommentsFromEntries(entries *Entries) {
+	filtered := make(Entries, 0, len(*entries))
+	for _, entry := range *entries {
+		if _, isComment := entry.(*Comment); !isComment {
+			filtered = append(filtered, entry)
+		}
+	}
+	*entries = filtered
+}
+
+// visitBlocks yields each block in the AST recursively.
+func visitBlocks(ast *AST, visitor func(*Block) error) error {
+	return Visit(ast, func(node Node, next func() error) error {
+		if block, ok := node.(*Block); ok {
+			visitor(block)
+		}
+		return next()
+	})
 }
 
 func cloneStrings(strings []string) []string {

--- a/util.go
+++ b/util.go
@@ -44,6 +44,9 @@ func addParentRefs(parent, node Node) {
 			addParentRefs(node, entry)
 		}
 
+	case *Comment:
+		node.Parent = parent
+
 	case *MapEntry:
 		node.Parent = parent
 


### PR DESCRIPTION
Allows parsing detached comments as nodes in the AST.

Allows distinguishing the following two scenarios (so that they can be roundtripped correctly if you Parse external HCL and then Marshal it back):

```hcl
// We see this as a LEADING comment
// that — because no empty lines separates it from the subsequent block —
// we see as semantically attached to the block.
// alecthomas/hcl parses it into the block's `Comments`.
// There is no change of behavior.
block {}
```

```hcl
// We see this as a DETACHED comment
// that — because empty lines separate it from the subsequent block —
// we see as semantically divorced from the block
// alecthomas/hcl parses it into a Comment node.
// The new behavior is opt-in.

block {}
```

Also,

```hcl
block {}
// We see this as a DETACHED comment
// that — because it trails the preceding block —
// we see as semantically divorced from the block
// alecthomas/hcl parses it into a Comment node _as well as_ TrailingComments.
// The new behavior is opt-in.
```