### PR TITLE
fix: Fix parsing identifiers that include (or end with) multiple dashes

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -510,7 +510,7 @@ func (m *Map) value() {}
 var (
 	lex = lexer.Must(lexer.New(lexer.Rules{
 		"Root": {
-			{"Ident", `\b[[:alpha:]]\w*(-\w+)*\b`, nil},
+			{"Ident", `\b[[:alpha:]][\w-]*`, nil},
 			{"Number", `^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?`, nil},
 			{"Heredoc", `<<[-]?(\w+\b)`, lexer.Push("Heredoc")},
 			{"String", `"(\\\d\d\d|\\.|[^"])*"|'(\\\d\d\d|\\.|[^'])*'`, nil},

--- a/parser_test.go
+++ b/parser_test.go
@@ -209,10 +209,10 @@ EOF
 		},
 		{name: "BlockWithLabels",
 			hcl: `
-				block label0 "label1" {}
+				block label--0 "label1" {}
 			`,
 			expected: hcl(
-				block("block", []string{"label0", "label1"}),
+				block("block", []string{"label--0", "label1"}),
 			),
 		},
 		{name: "NestedBlocks",


### PR DESCRIPTION
This is allowed by the spec: https://github.com/hashicorp/hcl/blob/main/hclsyntax/spec.md

resolves #39